### PR TITLE
Fix page location problem

### DIFF
--- a/src/main/java/io/github/toberocat/guiengine/components/AbstractGuiComponent.java
+++ b/src/main/java/io/github/toberocat/guiengine/components/AbstractGuiComponent.java
@@ -120,7 +120,12 @@ public abstract class AbstractGuiComponent implements GuiComponent {
         if (null == context || null == api) return;
 
         FunctionProcessor.callFunctions(clickFunctions, api, context);
-        context.render();
+        if (event.getHotbarButton() > 8) {
+            context.render(event.getHotbarButton() % 10);
+        } else {
+            context.render();
+        }
+
     }
 
     @Override

--- a/src/main/java/io/github/toberocat/guiengine/components/provided/embedded/EmbeddedGuiComponent.java
+++ b/src/main/java/io/github/toberocat/guiengine/components/provided/embedded/EmbeddedGuiComponent.java
@@ -80,7 +80,15 @@ public class EmbeddedGuiComponent extends AbstractGuiComponent {
     public void clickedComponent(@NotNull InventoryClickEvent event) {
         super.clickedComponent(event);
         if (!interactions || null == embedded) return;
-        InventoryClickEvent fakedEvent = new InventoryClickEvent(event.getView(), event.getSlotType(), event.getSlot() - Utils.translateToSlot(offsetX, offsetY), event.getClick(), event.getAction(), event.getHotbarButton());
+        int fakeHotBarButton = event.getHotbarButton();
+        if (fakeHotBarButton > 0) {
+            fakeHotBarButton = (fakeHotBarButton * 10) * 10 + offsetY;
+        } else if (fakeHotBarButton == 0) {
+            fakeHotBarButton = 1000 + offsetY;
+        } else {
+            fakeHotBarButton = (Math.abs(fakeHotBarButton) * 10 + 1) * 10 + offsetY;
+        }
+        InventoryClickEvent fakedEvent = new InventoryClickEvent(event.getView(), event.getSlotType(), event.getSlot() - Utils.translateToSlot(offsetX, offsetY), event.getClick(), event.getAction(), fakeHotBarButton);
         embedded.clickedComponent(fakedEvent);
     }
 


### PR DESCRIPTION
This problem is caused by function `render` in `GuiContext.java`
```java
public void render() {
    ItemStack[][] content2d = new ItemStack[height()][width()];
    interpreter().getRenderEngine().renderGui(content2d, this, viewer);

    ItemStack[] flatContent = inventory.getContents();
    for (int y = 0; y < height(); y++)
        System.arraycopy(content2d[y], 0, flatContent, y * width(), width());
    inventory.setContents(flatContent);
}
```
After clicked an item, it will execute in this order:
```
GuiContext.clickedComponent()
 ├─ GuiEvents.clickedComponent()
 └─ EmbeddedGuiComponent.clickedComponent()
     ├─ AbstractGuiComponent.clickedComponent()
     │   └─ context.render()
     └─ GuiContext.clickedComponent()
         ├─ GuiEvents.clickedComponent()
         └─ AbstractGuiComponent.clickedComponent()
             └─ context.render()
```
You can see that `context.render()` will be exectued twice, and `inventory.getContents()` will return same inventory contents.

But the `height` of these rendering operation is different. In first render, the height is `2` so the for loop will refresh the whole inventory. Then, in secone render, the `height` bacame `1`, and the inventory contents is same as the forst time, so the for loop will only refresh one line, but the `y` in for loop is started from `0` so the first line will become the copy of the second line.

So, I used the fakedEvent in `EmbeddedGuiComponent.java`, used a different munber format to use `hotBarButton` to transfer the `y` of page content
```
        0                 0          0
hotBarButton Value     Symbol     Y Value
```
So when hotBarButton is `-1`, Y value is `1`, the whole value will be: `111`, when hotBarButton is `2`, Y value is `2`, the whole value will be: `202`

Now it just work, maybe it will have better solution